### PR TITLE
Decouple column resizing from Media and timeline

### DIFF
--- a/src/lib/components/ResizeStalk.svelte
+++ b/src/lib/components/ResizeStalk.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  import { studio } from "$lib/stores";
+
+  export let resizeMode: "mediaCol" | "timelineCol" | "row" | null = null;
+</script>
+
+<div class="relative bg-neutral-800 flex justify-center items-center overflow-visible">
+  {#if resizeMode == "mediaCol" || resizeMode == "timelineCol"}
+    <div class="absolute w-5 h-full cursor-col-resize" on:mousedown={(e) => ($studio.resizeMode = resizeMode)} />
+  {:else if resizeMode == "row"}
+    <div class="absolute w-full h-5 cursor-row-resize" on:mousedown={(e) => ($studio.resizeMode = resizeMode)} />
+  {/if}
+</div>

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -1,5 +1,11 @@
 import { writable } from "svelte/store";
 
+export const studio = writable({
+  resizeMode: null,
+} as {
+  resizeMode: "row" | "mediaCol" | "timelineCol" | null;
+});
+
 export const media = writable({
   previewSource: "",
   selected: [],

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,76 +1,53 @@
 <script lang="ts">
   import MediaPool from "$lib/components/mediaPool/MediaPool.svelte";
   import Player from "$lib/components/Player.svelte";
+  import ResizeStalk from "$lib/components/ResizeStalk.svelte";
   import Timeline from "$lib/components/timeline/Timeline.svelte";
+  import { studio } from "$lib/stores";
   import "../app.css";
 
-  const handleResize = (e: MouseEvent) => {
-    if (!isResizing || !resizeMode) return;
-
-    if (resizeMode === "col") columnWidth = `${e.clientX}px`;
-    else if (resizeMode === "row") rowWidth = `calc(100vh - ${e.clientY}px)`;
-    else if (resizeMode === "corner") {
-      columnWidth = "{e.clientX}px";
-      rowWidth = `calc(100vh - ${e.clientY}px)`;
-      columnWidth = `${e.clientX}px`;
-    }
-  };
-
-  let columnWidth = "384px";
-  let rowWidth = "384px";
   let isResizing = false;
-  let resizeMode: "col" | "row" | "corner" | null = null;
+  let mediaColumnWidth = "40vw";
+  let timelineColumnWidth = "10vw";
+  let timelineHeight = "384px";
+
+  const handleResize = (e: MouseEvent) => {
+    if (!isResizing || !$studio.resizeMode) return;
+
+    if ($studio.resizeMode === "mediaCol") mediaColumnWidth = `${e.clientX}px`;
+    else if ($studio.resizeMode === "timelineCol") timelineColumnWidth = `${e.clientX}px`;
+    else if ($studio.resizeMode === "row") timelineHeight = `calc(100vh - ${e.clientY}px)`;
+  };
 </script>
 
 <main
-  style="--col-width:minmax(320px, {columnWidth}); --row-width:minmax(calc(256px), {rowWidth}););"
-  class="w-full h-[100dvh] bg-neutral-950 grid grid-cols-[var(--col-width),3px,minmax(0,1fr)] grid-rows-[minmax(0,1fr),3px,var(--row-width)] transition-none"
+  style="--row-width: minmax(256px, {timelineHeight});"
+  class="w-full h-[100dvh] bg-neutral-950 grid grid-cols-1 grid-rows-[minmax(0,1fr),3px,var(--row-width)] transition-none"
   class:select-none={isResizing}
   on:mousemove={(e) => handleResize(e)}
   on:mousedown={(e) => e.button === 0 && (isResizing = true)}
   on:mouseup={() => {
     isResizing = false;
-    resizeMode = null;
+    $studio.resizeMode = null;
   }}
 >
-  <div class="row-start-1 col-start-1">
+  <section
+    style="--media-col-width: minmax(320px, {mediaColumnWidth});"
+    class="grid grid-rows-1 grid-cols-[var(--media-col-width),3px,minmax(0,1fr)] transition-none"
+  >
     <MediaPool />
-  </div>
-
-  <div class="row-start-1 col-start-3 flex flex-col justify-center items-center gap-8 p-8">
-    <Player />
-  </div>
-
-  <div class="row-start-3 col-start-1">
-    <p class="text-white">tracks</p>
-  </div>
-
-  <div class="row-start-3 col-start-3">
+    <ResizeStalk resizeMode="mediaCol" />
+    <div class="flex flex-col justify-center items-center gap-8 p-8">
+      <Player />
+    </div>
+  </section>
+  <ResizeStalk resizeMode="row" />
+  <section
+    style="--timeline-col-width: minmax(320px, {timelineColumnWidth});"
+    class="grid grid-rows-1 grid-cols-[var(--timeline-col-width),3px,minmax(0,1fr)] transition-none"
+  >
+    <p>tracks</p>
+    <ResizeStalk resizeMode="timelineCol" />
     <Timeline />
-  </div>
-
-  <div class="row-start-2 col-start-3 flex justify-center items-center z-10 pointer-events-none">
-    <div class="w-24 h-0.5 bg-neutral-700 rounded-full" />
-  </div>
-  <div class="relative row-start-2 col-span-full bg-neutral-800 flex justify-center items-center overflow-visible">
-    <div class="absolute w-full mh-5 cursor-row-resize" on:mousedown={(e) => (resizeMode = "row")} />
-  </div>
-
-  <div class="col-start-2 row-start-1 flex justify-center items-center z-10 pointer-events-none">
-    <div class="w-0.5 h-24 bg-neutral-700 rounded-full" />
-  </div>
-  <div class="relative col-start-2 row-span-full bg-neutral-800 flex justify-center items-center overflow-visible">
-    <div class="absolute w-5 h-full cursor-col-resize" on:mousedown={(e) => (resizeMode = "col")} />
-  </div>
-
-  <div class="relative row-start-2 col-start-2 bg-neutral-600 flex justify-center items-center overflow-visible">
-    <div class="w-3 h-3 absolute bg-neutral-600" />
-    <div class="absolute w-4 h-4 cursor-move" on:mousedown={(e) => (resizeMode = "corner")} />
-  </div>
+  </section>
 </main>
-
-<style>
-  main {
-    grid-template-rows: 1fr, 2px, [];
-  }
-</style>


### PR DESCRIPTION
closes #13 

Decouples resize events from Media row and Timeline row, allowing for better default sizing (larger media pool, small timeline sidebar)

Also implements handy studio store for tracking global studio information