### PR TITLE
Fix webkit scrollbar

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -1,3 +1,9 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  ::-webkit-scrollbar {
+    display: none;
+  }
+}

--- a/src/lib/components/MediaPool.svelte
+++ b/src/lib/components/MediaPool.svelte
@@ -60,7 +60,7 @@
 
 <svelte:window on:keydown={handleKey} on:click={() => ($mediaPool.selected = [])} />
 
-<div class="relative pt-4 px-4 h-full overflow-scroll" on:dragover|preventDefault on:drop|preventDefault={handleDrop}>
+<div class="relative pt-4 px-4 h-full overflow-y-scroll" on:dragover|preventDefault on:drop|preventDefault={handleDrop}>
   <div class="flex justify-between gap-2">
     <input type="file" accept="video/*,image/*,audio/*" class="text-white h-8" multiple on:change={handleUpload} />
   </div>


### PR DESCRIPTION
Lazy fix. Ideally should update the scrollbar looks to match site colors.
The primary issue preventing scrollbar usage is the drag column separating the media pool and preview regions, which overlaps the scrollbar.